### PR TITLE
Fixed bug on patch, change token to key as 'key' is referenced in main 

### DIFF
--- a/.github/workflows/run-addon.yml
+++ b/.github/workflows/run-addon.yml
@@ -6,4 +6,4 @@ jobs:
   Run-Add-On:
     uses: MuckRock/documentcloud-addon-workflows/.github/workflows/run-addon.yml@v1
     secrets:
-      token: ${{ secrets.KEY }}
+      key: ${{ secrets.KEY }}

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ class OCRSpace(AddOn):
                 "language": document.language,
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
-            results = json.loads(response.text)
+            results = json.loads(resp.text)
             if results["IsErroredOnProcessing"]:
                 self.set_message(f"Error")
                 return

--- a/main.py
+++ b/main.py
@@ -34,7 +34,7 @@ class OCRSpace(AddOn):
                 if results["IsErroredOnProcessing"]:
                     self.set_message(f"Error")
                     return
-            else: 
+            except: 
                 traceback.print_exc()
                 sys.exit(1)
             pages = []

--- a/main.py
+++ b/main.py
@@ -29,8 +29,6 @@ class OCRSpace(AddOn):
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
             results = json.loads(resp.text)
-            print(results)
-            """
             if results["IsErroredOnProcessing"]:
                 self.set_message(f"Error")
                 return
@@ -61,7 +59,6 @@ class OCRSpace(AddOn):
                         )
                 pages.append(page)
             self.client.patch(f"/api/documents/{document.id}/", {"pages": pages})
-            """
 
 if __name__ == "__main__":
     OCRSpace().main()

--- a/main.py
+++ b/main.py
@@ -29,7 +29,8 @@ class OCRSpace(AddOn):
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
             results = resp.json()
-            if results["IsErroredOnProcessing"]:
+            res = json.loads(results)
+            if res["IsErroredOnProcessing"]:
                 self.set_message(f"Error")
                 return
             pages = []

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ add-on for DocumentCloud, using the editable text APIs
 """
 
 import os
-import json
 import requests
 from documentcloud.addon import AddOn
 from listcrunch import uncrunch
@@ -28,7 +27,7 @@ class OCRSpace(AddOn):
                 "language": document.language,
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
-            results = json.loads(resp.text)
+            results = resp.json()
             if results["IsErroredOnProcessing"]:
                 self.set_message(f"Error")
                 return

--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ class OCRSpace(AddOn):
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
             results = json.loads(resp.text)
+            print(results)
+            """
             if results["IsErroredOnProcessing"]:
                 self.set_message(f"Error")
                 return
@@ -59,7 +61,7 @@ class OCRSpace(AddOn):
                         )
                 pages.append(page)
             self.client.patch(f"/api/documents/{document.id}/", {"pages": pages})
-
+            """
 
 if __name__ == "__main__":
     OCRSpace().main()

--- a/main.py
+++ b/main.py
@@ -58,7 +58,7 @@ class OCRSpace(AddOn):
                             }
                         )
                 pages.append(page)
-            self.client.patch(f"/api/documents/{document.id}/", {"pages": pages})
+            self.client.patch(f"documents/{document.id}/", {"pages": pages})
 
 if __name__ == "__main__":
     OCRSpace().main()

--- a/main.py
+++ b/main.py
@@ -28,9 +28,8 @@ class OCRSpace(AddOn):
                 "language": document.language,
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
-            results = resp.json()
-            res = json.loads(results)
-            if res["IsErroredOnProcessing"]:
+            results = json.loads(response.text)
+            if results["IsErroredOnProcessing"]:
                 self.set_message(f"Error")
                 return
             pages = []

--- a/main.py
+++ b/main.py
@@ -4,7 +4,8 @@ add-on for DocumentCloud, using the editable text APIs
 """
 
 import os
-
+import traceback
+import sys
 import requests
 from documentcloud.addon import AddOn
 from listcrunch import uncrunch
@@ -29,9 +30,13 @@ class OCRSpace(AddOn):
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
             results = resp.json()
-            if results["IsErroredOnProcessing"]:
-                self.set_message(f"Error")
-                return
+            try:
+                if results["IsErroredOnProcessing"]:
+                    self.set_message(f"Error")
+                    return
+            else: 
+                traceback.print_exc()
+                sys.exit(1)
             pages = []
             for i, (page_results, (width, height)) in enumerate(
                 zip(results["ParsedResults"], page_spec)

--- a/main.py
+++ b/main.py
@@ -4,8 +4,7 @@ add-on for DocumentCloud, using the editable text APIs
 """
 
 import os
-import traceback
-import sys
+import json
 import requests
 from documentcloud.addon import AddOn
 from listcrunch import uncrunch
@@ -30,13 +29,9 @@ class OCRSpace(AddOn):
             }
             resp = requests.post(URL, headers={"apikey": os.environ["KEY"]}, data=data)
             results = resp.json()
-            try:
-                if results["IsErroredOnProcessing"]:
-                    self.set_message(f"Error")
-                    return
-            except: 
-                traceback.print_exc()
-                sys.exit(1)
+            if results["IsErroredOnProcessing"]:
+                self.set_message(f"Error")
+                return
             pages = []
             for i, (page_results, (width, height)) in enumerate(
                 zip(results["ParsedResults"], page_spec)


### PR DESCRIPTION
old patch run was throwing document does not exist because of duplicated /api//api/ in the URL
https://github.com/duckduckgrayduck/documentcloud-ocrspace-addon/actions/runs/4431432379/jobs/7774386270
